### PR TITLE
fix for bug where time after midnight was come back with undefined

### DIFF
--- a/src/__tests__/time-mapping.test.ts
+++ b/src/__tests__/time-mapping.test.ts
@@ -17,6 +17,8 @@ const testCases: SanitizedInputTestCase[] = [
   { input: '20:45', expected: 'Quarter to nine' },
   { input: '23:10', expected: 'Ten past eleven' },
   { input: '23:50', expected: 'Ten to midnight' },
+  { input: '0:10', expected: 'Ten past midnight' },
+  { input: '00:15', expected: 'Quarter past midnight' },
 ];
 describe('Test time outputs', () => {
   testCases.forEach((testCase) => {

--- a/src/conversion.ts
+++ b/src/conversion.ts
@@ -50,7 +50,7 @@ type allowedMinutes =
       | 59
     );
 /** Type representation of the allowed sanitized time format (HH:MM or H:MM). */
-export type SanitizedTimeFormat = `${singleDigitHours | doubleDigitHours}:${allowedMinutes}`;
+export type SanitizedTimeFormat = `${0 | '00' | singleDigitHours | doubleDigitHours}:${allowedMinutes}`;
 
 /** Takes a time string and converts it into `SanitizedTimeFormat` string format.
  *  @see SanitizedTimeFormat*/
@@ -108,7 +108,9 @@ export function numberToHumanFriendlyText(input: SanitizedTimeFormat) {
   ];
 
   const getHoursString = (relationToHour?: RelationToHour) =>
-    hours === 24 || (relationToHour === RelationToHour.AfterHalfPast && hours === 23)
+    hours === 24 ||
+    (relationToHour === RelationToHour.AfterHalfPast && hours === 23) ||
+    (relationToHour === RelationToHour.BeforeHalfPast && hours === 0)
       ? 'midnight'
       : oneToNineteen[(hours - (relationToHour === RelationToHour.AfterHalfPast ? 0 : 1)) % 12];
 


### PR DESCRIPTION
When a query such as `http://0.0.0.0:8080?numericTime=0:05` the result would be 'Five minutes past undefined'.

This is a fix for this.